### PR TITLE
Convert locale to dropdown

### DIFF
--- a/app/code/community/EW/UntranslatedStrings/Block/Adminhtml/Report/Grid.php
+++ b/app/code/community/EW/UntranslatedStrings/Block/Adminhtml/Report/Grid.php
@@ -11,7 +11,9 @@ class EW_UntranslatedStrings_Block_Adminhtml_Report_Grid extends Mage_Adminhtml_
         /* var $collection EW_UntranslatedStrings_Model_Resource_String_Collection */
         $collection = Mage::getResourceModel('ew_untranslatedstrings/string_collection');
         $collection->joinStoreCode();
-        //$collection->setOrder('encounter_count', Varien_Db_Select::SQL_DESC); //causes problems with grid sorting
+        
+        //@todo: I can't get this to return the correct results in the grid
+        //$collection->groupUntranslatedStrings();
 
         $this->setCollection($collection);
 
@@ -19,6 +21,7 @@ class EW_UntranslatedStrings_Block_Adminhtml_Report_Grid extends Mage_Adminhtml_
     }
 
     protected function _prepareColumns() {
+
         $this->addColumn('id', array(
             'header'    => $this->__('ID'),
             'align'     => 'left',
@@ -32,6 +35,8 @@ class EW_UntranslatedStrings_Block_Adminhtml_Report_Grid extends Mage_Adminhtml_
             'align'     => 'left',
             'width'     => '75px',
             'index'     => 'code',
+            // 'type'      => 'options'
+            // 'options'   => Mage::getModel('modulename/region')->getRegions()
         ));
 
         $this->addColumn('untranslated_string', array(
@@ -52,11 +57,12 @@ class EW_UntranslatedStrings_Block_Adminhtml_Report_Grid extends Mage_Adminhtml_
             'index'     => 'translation_module',
         ));
 
-
         $this->addColumn('locale', array(
             'header'    => $this->__('Locale'),
             'align'     => 'left',
             'index'     => 'locale',
+            'type'      => 'options',
+            'options'   => Mage::helper('ew_untranslatedstrings')->getEnabledStoreLocales()
         ));
 
         $this->addColumn('url_found', array(

--- a/app/code/community/EW/UntranslatedStrings/Block/Adminhtml/Report/Grid.php
+++ b/app/code/community/EW/UntranslatedStrings/Block/Adminhtml/Report/Grid.php
@@ -35,8 +35,6 @@ class EW_UntranslatedStrings_Block_Adminhtml_Report_Grid extends Mage_Adminhtml_
             'align'     => 'left',
             'width'     => '75px',
             'index'     => 'code',
-            // 'type'      => 'options'
-            // 'options'   => Mage::getModel('modulename/region')->getRegions()
         ));
 
         $this->addColumn('untranslated_string', array(

--- a/app/code/community/EW/UntranslatedStrings/Helper/Data.php
+++ b/app/code/community/EW/UntranslatedStrings/Helper/Data.php
@@ -128,4 +128,49 @@ class EW_UntranslatedStrings_Helper_Data extends Mage_Core_Helper_Abstract
         //not enabled, so stick to configured locale
         return array(Mage::app()->getLocale()->getLocaleCode());
     }
+
+    /**
+     * Return array of all store locales and label those not used
+     * @return array
+     */
+    public function getEnabledStoreLocales() {
+
+        $local_options = array();
+        $available_locales = array();
+
+        // loop through the stores and grab the configured locale
+        $stores = Mage::app()->getStores();
+        foreach ($stores as $store) {
+            $store_id = $store->getId();
+            $available_locales[] = Mage::getStoreConfig('general/locale/code', $store_id);
+        }
+
+        // loop through all Magento locales
+        $locales = Mage::app()->getLocale()->getOptionLocales();
+        foreach ($locales as $locale) {
+
+            // does the locale match a configured store locale
+            if (in_array($locale['value'], $available_locales)) {
+
+                $local_options[$locale['value']] = $locale['value'];
+
+            } else {
+
+                // edge case to allow for stray database entries
+                // locales that don't exist in store but did at one time and are in db
+                $db_locales = Mage::getResourceModel('ew_untranslatedstrings/string_collection')->getLocalesIdentified();
+                if (in_array($locale['value'], $db_locales)) {
+                    $local_options[$locale['value']] = $locale['value'];
+                } else {
+                    // uncomment to show unsed locales
+                    //$local_options[$locale['value']] = $this->__('Unused: ') . $locale['value'];
+                }
+
+            }
+        }
+
+        return $local_options;
+
+    }
+
 }

--- a/app/code/community/EW/UntranslatedStrings/Model/Resource/String/Collection.php
+++ b/app/code/community/EW/UntranslatedStrings/Model/Resource/String/Collection.php
@@ -4,6 +4,7 @@ class EW_UntranslatedStrings_Model_Resource_String_Collection extends Mage_Core_
 {
     private $_joinedStoreCode = false;
     private $_interferWithCountSql = false;
+    private $_groupedUntranslatedStrings = false;
 
     protected function _construct() {
         $this->_init('ew_untranslatedstrings/string');
@@ -24,6 +25,16 @@ class EW_UntranslatedStrings_Model_Resource_String_Collection extends Mage_Core_
     }
 
     /**
+     * @todo: Group untranslated strings together by locale
+     */
+    public function groupUntranslatedStrings() {
+        if(!$this->_groupedUntranslatedStrings) {
+            $this->getSelect()->group(array('locale','untranslated_string'));
+        }
+        $this->_groupedUntranslatedStrings = true;
+    }
+
+    /**
      * Account for group and having clauses, if any
      *
      * @return Varien_Db_Select
@@ -37,6 +48,7 @@ class EW_UntranslatedStrings_Model_Resource_String_Collection extends Mage_Core_
         $this->_renderFilters();
 
         $countSelect = clone $this->getSelect();
+        //$countSelect->reset(Zend_Db_Select::GROUP);
         $countSelect->reset(Zend_Db_Select::ORDER);
         $countSelect->reset(Zend_Db_Select::LIMIT_COUNT);
         $countSelect->reset(Zend_Db_Select::LIMIT_OFFSET);
@@ -85,6 +97,27 @@ class EW_UntranslatedStrings_Model_Resource_String_Collection extends Mage_Core_
         $idsSelect->columns($this->getResource()->getIdFieldName(), 'main_table');
         return $this->getConnection()->fetchCol($idsSelect);
     }
+
+    /**
+     * Retrieves a list of all locales identified
+     * @return array
+     */
+     public function getLocalesIdentified() {
+
+        $select = $this->addFieldToSelect('locale')
+                            ->getSelect()
+                            ->group('locale');
+
+        $locales = array();
+        $results = $select->query()->fetchAll();
+
+        foreach ($results as $data) {
+            $locales[] = $data['locale'];
+        }
+
+        return $locales;
+
+     }
 
     /**
      * Configures collection to be summary of


### PR DESCRIPTION
This PR converts the locale column of the grid into a dropdown. It contains some commented code to make locale and untranslated_string columns a group by condition of the collection. I failed at getting the grid to return the correct amount of rows and I suspect this is due to a bug in the way Magento deals with grids and group by conditions on collections.
