### PR TITLE
Export all the log files into a ZIP file which contains CSV files per locale

### DIFF
--- a/app/code/community/EW/UntranslatedStrings/Block/Adminhtml/Report/Grid.php
+++ b/app/code/community/EW/UntranslatedStrings/Block/Adminhtml/Report/Grid.php
@@ -80,7 +80,8 @@ class EW_UntranslatedStrings_Block_Adminhtml_Report_Grid extends Mage_Adminhtml_
             'type'      => 'number'
         ));
 
-        $this->addExportType('*/*/exportCsv', $this->__('CSV'));
+        $this->addExportType('*/*/exportCsv', $this->__('CSV (contains filter result below)'));
+        $this->addExportType('*/*/exportZip', $this->__('ZIP (contains all per language)'));
 
         return parent::_prepareColumns();
     }

--- a/app/code/community/EW/UntranslatedStrings/Model/ExportToZip.php
+++ b/app/code/community/EW/UntranslatedStrings/Model/ExportToZip.php
@@ -1,0 +1,107 @@
+<?php
+
+class EW_UntranslatedStrings_Model_ExportToZip
+{
+    protected function getCsvByLocaleCode($localeCode)
+    {
+        /** @var EW_UntranslatedStrings_Model_Resource_String_Collection $collection */
+        $collection = Mage::getResourceModel('ew_untranslatedstrings/string_collection');
+        $collection->joinStoreCode();
+        $collection->addFieldToFilter('locale', $localeCode);
+
+        /** @var EW_UntranslatedStrings_Block_Adminhtml_Report_Grid $grid */
+        $grid = Mage::getBlockSingleton('ew_untranslatedstrings/adminhtml_report_grid');
+        $grid->setCollection($collection);
+
+        // filtering for a the given locale
+        $this->resetFilters();
+        $grid->setDefaultFilter(['locale' => $localeCode]);
+        $file = $grid->getCsvFile();
+
+        return [
+            'locale' => $localeCode,
+            'path'   => $file['value'],
+        ];
+    }
+
+    /**
+     * Archive input files into a ZIP file and return the path of the output file
+     */
+    protected function archive(array $files)
+    {
+        $zipFilePath = $this->getZipFilePath();
+        $zip = $this->createZipArchive($zipFilePath);
+
+        foreach ($files as $file) {
+            $localname = sprintf('untranslated_strings_report_%s.csv', $file['locale']);
+            $zip->addFile($file['path'], $localname);
+        }
+
+        $zip->close();
+        $this->removeCsvFiles($files);
+
+        return $zipFilePath;
+    }
+
+    /**
+     * @param $zipFilePath
+     *
+     * @return ZipArchive
+     * @throws Mage_Core_Exception
+     */
+    protected function createZipArchive($zipFilePath)
+    {
+        $zip = new ZipArchive();
+
+        if ($zip->open($zipFilePath, ZipArchive::CREATE)!==TRUE) {
+            Mage::throwException("cannot open <$zipFilePath>\n");
+        }
+
+        if (file_exists($zipFilePath)) {
+            unlink($zipFilePath);
+        }
+
+        return $zip;
+    }
+
+    public function getZip()
+    {
+        $untranslatedLocaleCodes = Mage::getModel('ew_untranslatedstrings/string')->getUntranslatedLocaleCodes();
+        $csvFilesByLocale = [];
+        foreach ($untranslatedLocaleCodes as $localeCode) {
+            $csvFilesByLocale[] = $this->getCsvByLocaleCode($localeCode);
+        }
+
+        return $this->archive($csvFilesByLocale);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getZipFilePath()
+    {
+        $zipFilePath = Mage::getBaseDir('var').DS.'export'.DS.'untranslated_strings_report.zip';
+
+        return $zipFilePath;
+    }
+
+    protected function removeCsvFiles($files)
+    {
+        foreach ($files as $file) {
+            unlink($file['path']);
+        }
+    }
+
+    /**
+     * Reset filters on the grid, so the ZIP will contain all the log entries
+     */
+    protected function resetFilters()
+    {
+        $session = Mage::getSingleton('adminhtml/session');
+        $session->unsetData('ew_untranslatedstrings_adminhtml_report_gridfilter');
+        $session->unsetData('ew_untranslatedstrings_adminhtml_report_griddir');
+        $session->unsetData('ew_untranslatedstrings_adminhtml_report_gridsort');
+        $session->unsetData('ew_untranslatedstrings_adminhtml_report_gridpage');
+        $session->unsetData('ew_untranslatedstrings_adminhtml_report_gridlimit');
+    }
+}

--- a/app/code/community/EW/UntranslatedStrings/Model/String.php
+++ b/app/code/community/EW/UntranslatedStrings/Model/String.php
@@ -41,4 +41,21 @@ class EW_UntranslatedStrings_Model_String extends Mage_Core_Model_Abstract
 
         $this->getResource()->purgeStrings($purgeIds);
     }
+
+    /**
+     * List locale codes where we have found untranslated strings
+     *
+     * @return array
+     */
+    public function getUntranslatedLocaleCodes()
+    {
+        $collection = Mage::getResourceModel('ew_untranslatedstrings/string_collection');
+        $collection->configureSummary();
+        $localeCodes = [];
+        foreach ($collection->load() as $summary) {
+            $localeCodes[] = $summary['locale'];
+        }
+
+        return $localeCodes;
+    }
 }

--- a/app/code/community/EW/UntranslatedStrings/controllers/Adminhtml/UntranslatedController.php
+++ b/app/code/community/EW/UntranslatedStrings/controllers/Adminhtml/UntranslatedController.php
@@ -184,4 +184,29 @@ class EW_UntranslatedStrings_Adminhtml_UntranslatedController extends Mage_Admin
 
         $this->_prepareDownloadResponse($fileName, $content);
     }
+
+    /**
+     * All log files per language can be downloaded together as zip file
+     */
+    public function exportZipAction()
+    {
+        // reset filtering so the ZIP file will contains all the log entries
+        $this->getRequest()->setParam('filter', null);
+        $this->getRequest()->setParam('dir', null);
+        $this->getRequest()->setParam('sort', null);
+
+        /** @var EW_UntranslatedStrings_Model_ExportToZip $model */
+        $model = Mage::getModel('ew_untranslatedstrings/exportToZip');
+        $zipFile = $model->getZip();
+        $fileName = basename($zipFile);
+
+        $this->getResponse()->clearAllHeaders();
+        $this->getResponse()->setHeader('Content-Type', 'application/zip');
+        $this->getResponse()->setHeader('Content-Disposition', "attachment; filename=$fileName");
+        $this->getResponse()->setHeader('Content-Length', filesize($zipFile));
+        $this->getResponse()->sendHeaders();
+
+        readfile($zipFile);
+        exit;
+    }
 }

--- a/modman
+++ b/modman
@@ -1,3 +1,3 @@
-app/code/community/EW/UntranslatedStrings
-app/etc/modules/EW_UntranslatedStrings.xml
-app/design/adminhtml/default/default/layout/ew_untranslatedstrings.xml
+app/code/community/EW/UntranslatedStrings app/code/community/EW/UntranslatedStrings
+app/etc/modules/EW_UntranslatedStrings.xml app/etc/modules/EW_UntranslatedStrings.xml
+app/design/adminhtml/default/default/layout/ew_untranslatedstrings.xml app/design/adminhtml/default/default/layout/ew_untranslatedstrings.xml


### PR DESCRIPTION
Our client asked this option because they have many store views with many different languages. It makes their life easier when it comes to translating. I thought it might be useful for anyone else.